### PR TITLE
Fix step freeze with timeouts

### DIFF
--- a/getappid.py
+++ b/getappid.py
@@ -29,8 +29,17 @@ headers = {
     'Content-Type': 'application/json'
 }
 
-# Make the request to list apps
-response = requests.get('https://api.appstoreconnect.apple.com/v1/apps', headers=headers)
+# Make the request to list apps with timeout and error handling
+print("Requesting App ID from Apple...")
+try:
+    response = requests.get(
+        'https://api.appstoreconnect.apple.com/v1/apps',
+        headers=headers,
+        timeout=30
+    )
+except requests.exceptions.RequestException as e:
+    print(f"Network error while requesting app list: {e}")
+    sys.exit(1)
 
 # Try to parse the response as JSON
 try:

--- a/machine_info.sh
+++ b/machine_info.sh
@@ -5,7 +5,7 @@ echo ""
 
 # Public IP Address
 echo "Public IP Address:"
-curl -s ifconfig.me
+curl -s --max-time 10 ifconfig.me
 echo ""
 echo "------------------------"
 

--- a/manage_version.py
+++ b/manage_version.py
@@ -42,7 +42,10 @@ def get_latest_app_version(app_id, jwt_token):
     url = f'https://api.appstoreconnect.apple.com/v1/apps/{app_id}/appStoreVersions'
 
     # Make the GET request
-    response = requests.get(url, headers=headers)
+    try:
+        response = requests.get(url, headers=headers, timeout=30)
+    except requests.exceptions.RequestException as e:
+        return {"versionString": None, "appStoreVersionId": None, "error": f"Network error: {e}"}
     # Comment if not debug
     #print(f"The get_latest_app_version response is: {response.json()}")
     # Check if the request was successful
@@ -107,7 +110,10 @@ def create_app_store_version(app_id, version_string, jwt_token):
             }
         }
     }
-    response = requests.post(url, json=payload, headers=headers)
+    try:
+        response = requests.post(url, json=payload, headers=headers, timeout=30)
+    except requests.exceptions.RequestException as e:
+        return {"error": f"Network error: {e}"}
     # Comment if not debug
     #print(f"The create_app_store_version response is: {response.json()}")
     return response.json()


### PR DESCRIPTION
## Summary
- add network timeout and logging when requesting Apple app list
- add timeout handling for version management
- limit public IP lookup to 10 seconds

## Testing
- `python3 -m py_compile getappid.py manage_version.py check_rating.py`
