### PR TITLE
Fix system profiler hang

### DIFF
--- a/machine_info.sh
+++ b/machine_info.sh
@@ -53,6 +53,29 @@ echo "------------------------"
 
 # Display Information
 echo "Display Information:"
-system_profiler SPDisplaysDataType
+timeout_cmd=""
+if command -v timeout >/dev/null 2>&1; then
+    timeout_cmd="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    timeout_cmd="gtimeout"
+fi
+
+if [ -n "$timeout_cmd" ]; then
+    # Use setsid so the entire process group is terminated on timeout
+    $timeout_cmd 10 setsid system_profiler SPDisplaysDataType \
+        || echo "Failed or timeout retrieving display info"
+else
+    # Manually kill the process group after 10s if timeout isn't available
+    setsid system_profiler SPDisplaysDataType &
+    sp_pid=$!
+    {
+        sleep 10
+        if kill -0 -- -$sp_pid >/dev/null 2>&1; then
+            kill -9 -- -$sp_pid >/dev/null 2>&1
+            echo "Killed hanging system_profiler"
+        fi
+    } &
+    wait $sp_pid 2>/dev/null || true
+fi
 echo ""
 echo "------------------------"


### PR DESCRIPTION
## Summary
- protect `system_profiler SPDisplaysDataType` call with timeout logic to avoid freezing
- use `setsid` so the entire process group is terminated if the command hangs

## Testing
- `bash -n machine_info.sh`
- `python3 -m py_compile check_rating.py getappid.py manage_version.py`
